### PR TITLE
metainfo: developer_name is deprecated

### DIFF
--- a/io.github.gnu_octave.doctest.metainfo.xml
+++ b/io.github.gnu_octave.doctest.metainfo.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-Copyright 2016, 2019, 2023 Colin B. Macdonald
+Copyright 2016, 2019, 2023-2024 Colin B. Macdonald
 SPDX-License-Identifier: FSFAP
 
 Copying and distribution of this file, with or without modification,
@@ -25,11 +25,12 @@ without any warranty.
     <keyword>testing</keyword>
     <keyword>documentation</keyword>
   </keywords>
-  <translation/>
   <url type="homepage">https://octave.sourceforge.io/doctest</url>
   <url type="bugtracker">https://github.com/gnu-octave/octave-doctest/issues/new</url>
   <metadata_license>FSFAP</metadata_license>
   <project_license>BSD-3-Clause</project_license>
-  <developer_name>Octave Community</developer_name>
+  <developer id="octave.org">
+    <name>Octave Community</name>
+  </developer>
   <update_contact>octave-maintainers@gnu.org</update_contact>
 </component>


### PR DESCRIPTION
See [1].

[1] https://freedesktop.org/software/appstream/docs/chap-Metadata.html#tag-developer