### PR TITLE
CI: validate the metainfo

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -54,7 +54,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
-      - name: Install Flatpak
+      - name: Install Flatpak and add Flathub
         run: |
           whoami
           uname -a
@@ -62,11 +62,11 @@ jobs:
           sudo apt-get install -y flatpak
           sudo flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
           sudo flatpak install -y org.freedesktop.appstream.cli
+      - name: List appstream.cli version
+        run: |
+          flatpak run org.freedesktop.appstream.cli --version
       - name: Validate
         run: |
-          pwd
-          ls
-          flatpak run org.freedesktop.appstream.cli --version
           flatpak run org.freedesktop.appstream.cli validate --strict --pedantic --explain io.github.gnu_octave.doctest.metainfo.xml
 
   # Built-in Self Tests for various supported Octave

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -49,6 +49,20 @@ jobs:
         run: |
           octave --eval "pkg uninstall doctest; pkg list"
 
+  appstream-validate:
+    runs-on: fedora:40
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Appstream
+        run: |
+          sudo uname -a
+          sudo dnf install -y appstream
+          appstreamcli --version
+      - name: Validate
+        run: |
+          pwd
+          ls
+          appstreamcli validate --strict --pedantic --explain io.github.gnu_octave.doctest.metainfo.xml
 
   # Built-in Self Tests for various supported Octave
   # TODO: fail-fast -> true later

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -50,19 +50,24 @@ jobs:
           octave --eval "pkg uninstall doctest; pkg list"
 
   appstream-validate:
-    runs-on: fedora:40
+    # maybe a later Ubuntu will have appstream >= 1, for now we pull from flatpak
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
-      - name: Install Appstream
+      - name: Install Flatpak
         run: |
-          sudo uname -a
-          sudo dnf install -y appstream
-          appstreamcli --version
+          whoami
+          uname -a
+          sudo apt-get update
+          sudo apt-get install -y flatpak
+          sudo flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
+          sudo flatpak install -y org.freedesktop.appstream.cli
       - name: Validate
         run: |
           pwd
           ls
-          appstreamcli validate --strict --pedantic --explain io.github.gnu_octave.doctest.metainfo.xml
+          flatpak run org.freedesktop.appstream.cli --version
+          flatpak run org.freedesktop.appstream.cli validate --strict --pedantic --explain io.github.gnu_octave.doctest.metainfo.xml
 
   # Built-in Self Tests for various supported Octave
   # TODO: fail-fast -> true later


### PR DESCRIPTION
Its not as simple as on GitLab, b/c we can only (easily) run Ubuntu images and their Appstream package is too old (< 0.16.3)

Instead we install Flatpak, add Flathub and pull `org.freedesktop.appstream.cli`, which seems to work but feels a bit "heavy".